### PR TITLE
feat: enhance Zsh completion with menu selection

### DIFF
--- a/lib/src/installer/shell_completion_configuration.dart
+++ b/lib/src/installer/shell_completion_configuration.dart
@@ -78,6 +78,9 @@ if type compdef &>/dev/null; then
     IFS=\$'\n' reply=(\$(COMP_CWORD="\$((CURRENT-1))" COMP_LINE="\$BUFFER" COMP_POINT="\$CURSOR" $rootCommand completion -- "\${words[@]}"))
     IFS=\$si
 
+    zstyle ':completion:*' menu yes select
+    zstyle ':completion:*' list-colors ''
+
     if [[ -z "\$reply" ]]; then
         _path_files
     else 


### PR DESCRIPTION
## Status

**READY**

## Description

This pull request enhances Zsh completion support by adding interactive menu selection with completion lists. Specifically, it introduces two `zstyle` configurations:
- `zstyle ':completion:*' menu yes select`: Enables a menu-style completion interface in Zsh, allowing users to navigate options with arrow keys.
- `zstyle ':completion:*' list-colors ''`: Adds color highlighting to completion suggestions for better visibility.


## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore